### PR TITLE
set no_compressed_initramfs to no to avoid breaking for users with compressed initramfs

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -277,7 +277,7 @@ _minor=5
 # this can reduce the kernel size, but probably wont make the kernel use less ram.
 #
 # if you do not compress your initramfs, you can set to yes. it reduces the size of the vmlinuz binary
-: "${_no_compressed_initramfs:=yes}"
+: "${_no_compressed_initramfs:=no}"
 
 # disable VM support
 #


### PR DESCRIPTION
to avoid breaking for people that have a compressed initramfs (biggest change, trust ^^)
because else no more boot if its set to yes and the user has a compressed initramfs
this is the biggest change in linux-catgirl, trust ^^*

> * : source : i made it up ™️ 