### PR TITLE
Add `flex` & `bison` as makedepends

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -905,6 +905,8 @@ makedepends=(
   tar
   xz
   zstd
+  flex
+  bison
 )
 
 _patchsource_cachyos="https://raw.githubusercontent.com/cachyos/kernel-patches/master/${_major}"


### PR DESCRIPTION
Yes but not all users, like me, has `base-devel` installed. The Linux build process will just continue and crash in the middle of it due to the lack of these depends.

This PR fixes that, making sure that `flex` and `bison` are makedepends.