### PR TITLE
set preempt to full by default

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -905,6 +905,8 @@ makedepends=(
   tar
   xz
   zstd
+  flex
+  bison
 )
 
 _patchsource_cachyos="https://raw.githubusercontent.com/cachyos/kernel-patches/master/${_major}"

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -188,7 +188,7 @@ _minor=.4
 # If unsure, select `lazy`
 #
 # [^1]: except critical sections
-: "${_preempt:=lazy}"
+: "${_preempt:=full}"
 
 # Optimize kernel for a specific processor
 #


### PR DESCRIPTION
Setting preempt to 'full' by default, as it's the standard in most distros nowadays, such as ubuntu, which they have a [page talking about it](https://discourse.ubuntu.com/t/fine-tuning-the-ubuntu-24-04-kernel-for-low-latency-throughput-and-power-efficiency/44834) and after my own tests, (while i don't have any benchmarks of it), it seems that there isn't any issues.

Quoting Ubuntu's page :
> A fully-preemptible kernel is most suitable for low-latency workloads - such as gaming, live-streaming, multimedia, etc. - since high-priority tasks have more chances to interrupt low-priority tasks and acquire a CPU. However, there is a cost to pay in terms of throughput with the additional preemption.

So, in which cases should preempt not be set to full then? Well, Quoting Ubuntu again,
> Typical server or high-performance computing workloads may prefer a less responsive kernel with fewer interruptions, yet capable of sustaining higher computational performance. In such a scenario, voluntary preemption may be preferred.

Now, this may need some testing before being set as default in the PKGBUILD? but in theory, it shouldn't cause any issues, unless your workload is focused towards HPC / server workloads. tho, if most distros nowadays uses full preemption by default, then i guess it shouldn't hurt to set it to full here by default too? and if anything, people can just switch it back to lazy themself.